### PR TITLE
[#1] Short Url 도메인 객체 생성

### DIFF
--- a/src/main/java/com/url/shortener/UrlShortenerBackApplication.java
+++ b/src/main/java/com/url/shortener/UrlShortenerBackApplication.java
@@ -2,7 +2,9 @@ package com.url.shortener;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UrlShortenerBackApplication {
 

--- a/src/main/java/com/url/shortener/domain/Url.java
+++ b/src/main/java/com/url/shortener/domain/Url.java
@@ -1,0 +1,52 @@
+package com.url.shortener.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "url")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Url {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(length = 1000, nullable = false)
+    private String originalUrl;
+
+    @Column(length = 50, nullable = false)
+    private String shortUrl;
+
+    @ColumnDefault("0")
+    @Column(nullable = false)
+    private Integer requestCount;
+
+    @ColumnDefault("1")
+    @Column(nullable = false)
+    private Integer shorteningCount;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDatetime;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDatetime;
+}


### PR DESCRIPTION
## PR 설명
> 이슈 #1 
- Short Url에 대한 도메인 객체 정의

### 도메인 객체 설명 (Url.java)
- `Long id` : url 테이블의 pk
- `String originalUrl` : 변환 할 대상인 Long URL
- `String shortUrlKey` : 변환 후 짧아진 Short URL의 key 부분 (앞의 도메인 부분 제거하고 key만 남김)
- `Integer requestCount` : Short URL로의 접속 횟수
- `Integer shorteningCount` : 특정 Long URL -> Short URL 변환 횟수 (어떤 사이트가 몇 번이나 단축이 시도되었는지)
- `LocalDatetime createdDatetime` : 생성 시간
- `LocalDatetime updatedDatetime` : 수정 시간

---

## 작업 완료 목록
- [x] 도메인 클래스 코드 작성