### PR TITLE
[#6] 비즈니스 로직 및 전역 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/url/shortener/controller/UrlController.java
+++ b/src/main/java/com/url/shortener/controller/UrlController.java
@@ -14,6 +14,7 @@ import com.url.shortener.dto.response.UrlResponse;
 import com.url.shortener.service.UrlService;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,7 +25,7 @@ public class UrlController {
 
     @PostMapping("/api/short-urls")
     @ResponseStatus(HttpStatus.CREATED)
-    public UrlIdResponse createShortUrl(@RequestBody UrlRequest urlRequest) {
+    public UrlIdResponse createShortUrl(@Valid @RequestBody UrlRequest urlRequest) {
         return urlService.createShortUrl(urlRequest);
     }
 

--- a/src/main/java/com/url/shortener/domain/Url.java
+++ b/src/main/java/com/url/shortener/domain/Url.java
@@ -1,5 +1,7 @@
 package com.url.shortener.domain;
 
+import static com.url.shortener.exception.ExceptionRule.*;
+
 import java.time.LocalDateTime;
 
 import org.hibernate.annotations.ColumnDefault;
@@ -9,7 +11,9 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.url.shortener.exception.UrlException;
 import com.url.shortener.utils.Base62Util;
+import com.url.shortener.utils.UrlConnectionUtil;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,6 +59,8 @@ public class Url {
     private LocalDateTime updatedDatetime;
 
     private Url(String originalUrl) {
+        validateOriginalUrlIsValid(originalUrl);
+
         this.originalUrl = originalUrl;
     }
 
@@ -72,5 +78,11 @@ public class Url {
 
     public void increaseShorteningCount() {
         this.shorteningCount += 1;
+    }
+
+    private void validateOriginalUrlIsValid(String originalUrl) {
+        if (!UrlConnectionUtil.isValidUrl(originalUrl)) {
+            throw new UrlException(ORIGINAL_URL_INVALID, originalUrl);
+        }
     }
 }

--- a/src/main/java/com/url/shortener/dto/request/UrlRequest.java
+++ b/src/main/java/com/url/shortener/dto/request/UrlRequest.java
@@ -2,6 +2,7 @@ package com.url.shortener.dto.request;
 
 import com.url.shortener.domain.Url;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(staticName = "from")
 public class UrlRequest {
 
+    @NotEmpty(message = "Original Url이 입력되지 않음")
     private String originalUrl;
 
     public Url toEntity() {

--- a/src/main/java/com/url/shortener/dto/response/ExceptionResponse.java
+++ b/src/main/java/com/url/shortener/dto/response/ExceptionResponse.java
@@ -1,0 +1,19 @@
+package com.url.shortener.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponse {
+
+    private final String requestUrl;
+    private final String message;
+    private final Object[] rejectedValues;
+
+    @Builder
+    private ExceptionResponse(String requestUrl, String message, Object[] rejectedValues) {
+        this.requestUrl = requestUrl;
+        this.message = message;
+        this.rejectedValues = rejectedValues;
+    }
+}

--- a/src/main/java/com/url/shortener/exception/BusinessException.java
+++ b/src/main/java/com/url/shortener/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package com.url.shortener.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+    private final ExceptionRule exceptionRule;
+    private final Object[] rejectedValues;
+
+    protected BusinessException(ExceptionRule exceptionRule, Object... rejectedValues) {
+        super(exceptionRule.getMessage());
+        this.exceptionRule = exceptionRule;
+        this.rejectedValues = rejectedValues;
+    }
+}

--- a/src/main/java/com/url/shortener/exception/ExceptionRule.java
+++ b/src/main/java/com/url/shortener/exception/ExceptionRule.java
@@ -1,0 +1,26 @@
+package com.url.shortener.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionRule {
+
+    ORIGINAL_URL_INVALID(HttpStatus.BAD_REQUEST, "올바르지 않은 Original URL 입력"),
+    SHORT_URL_NOT_EXISTED(HttpStatus.NOT_FOUND, "입력한 ID에 해당하는 Short URL을 찾을 수 없음"),
+    SHORT_URL_KEY_INVALID(HttpStatus.BAD_REQUEST, "올바르지 않은 Short URL Key 입력"),
+    SHORT_URL_KEY_NOT_EXISTED(HttpStatus.NOT_FOUND, "입력한 Short URL Key를 찾을 수 없음"),
+    SHORT_URL_CANNOT_BE_SHORTENED(HttpStatus.BAD_REQUEST, "Short URL은 더이상 단축할 수 없음"),
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "사용자 입력 유효성 검사 실패"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URL에 해당하는 리소스를 찾을 수 없음"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP Method 요청 발생"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "기타 서버 내부 에러 발생"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/url/shortener/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/url/shortener/exception/GlobalExceptionHandler.java
@@ -1,0 +1,121 @@
+package com.url.shortener.exception;
+
+import static com.url.shortener.exception.ExceptionRule.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import com.url.shortener.dto.response.ExceptionResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 404 NOT FOUND
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        String requestUrl = e.getRequestURL();
+        String message = NOT_FOUND.getMessage();
+
+        log.error("[ERROR] {} => 요청 URL : {}", message, requestUrl, e);
+
+        ExceptionResponse response = ExceptionResponse.builder()
+            .requestUrl(requestUrl)
+            .message(message)
+            .build();
+
+        return ResponseEntity.status(NOT_FOUND.getStatus()).body(response);
+    }
+
+    // 405 METHOD NOT ALLOWED
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
+        HttpRequestMethodNotSupportedException e,
+        HttpServletRequest request
+    ) {
+        String message = METHOD_NOT_ALLOWED.getMessage();
+
+        log.error("[ERROR] {} => 지원 메서드 : {} | 요청 메서드 : {}", message, e.getSupportedMethods(), e.getMethod(), e);
+
+        ExceptionResponse response = ExceptionResponse.builder()
+            .requestUrl(request.getRequestURI())
+            .message(message)
+            .build();
+
+        return ResponseEntity.status(METHOD_NOT_ALLOWED.getStatus()).body(response);
+    }
+
+    // Request DTO Field Validation
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e,
+        HttpServletRequest request
+    ) {
+        String message = BAD_REQUEST.getMessage();
+        List<FieldError> errors = e.getBindingResult()
+            .getAllErrors()
+            .stream()
+            .map(FieldError.class::cast)
+            .toList();
+
+        log.error("[ERROR] {}", message, e);
+        for (FieldError error : errors) {
+            log.error("{} => {} : {}", error.getDefaultMessage(), error.getField(), error.getRejectedValue());
+        }
+
+        Object[] rejectedValues = errors.stream()
+            .map(FieldError::getRejectedValue)
+            .toArray();
+
+        ExceptionResponse response = ExceptionResponse.builder()
+            .requestUrl(request.getRequestURI())
+            .message(message)
+            .rejectedValues(rejectedValues)
+            .build();
+
+        return ResponseEntity.status(BAD_REQUEST.getStatus()).body(response);
+    }
+
+    // Business Exception Handler
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
+        ExceptionRule exceptionRule = e.getExceptionRule();
+        Object[] rejectedValues = e.getRejectedValues();
+        String message = exceptionRule.getMessage();
+
+        log.error("[ERROR] {} => 원인 값 : {}", message, rejectedValues, e);
+
+        ExceptionResponse response = ExceptionResponse.builder()
+            .requestUrl(request.getRequestURI())
+            .message(message)
+            .rejectedValues(rejectedValues)
+            .build();
+
+        return ResponseEntity.status(exceptionRule.getStatus()).body(response);
+    }
+
+    // Unexpected Exception Handler
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception e, HttpServletRequest request) {
+        String message = INTERNAL_SERVER_ERROR.getMessage();
+
+        log.error("[ERROR] {}", message, e);
+
+        ExceptionResponse response = ExceptionResponse.builder()
+            .requestUrl(request.getRequestURI())
+            .message(message)
+            .build();
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/url/shortener/exception/UrlException.java
+++ b/src/main/java/com/url/shortener/exception/UrlException.java
@@ -1,0 +1,8 @@
+package com.url.shortener.exception;
+
+public class UrlException extends BusinessException {
+
+    public UrlException(ExceptionRule exceptionRule, Object... rejectedValues) {
+        super(exceptionRule, rejectedValues);
+    }
+}

--- a/src/main/java/com/url/shortener/repository/UrlRepository.java
+++ b/src/main/java/com/url/shortener/repository/UrlRepository.java
@@ -11,4 +11,6 @@ public interface UrlRepository extends JpaRepository<Url, Long> {
     Optional<Url> findByOriginalUrl(String originalUrl);
 
     Optional<Url> findByShortUrlKey(String key);
+
+    boolean existsByShortUrlKey(String key);
 }

--- a/src/main/java/com/url/shortener/utils/UrlConnectionUtil.java
+++ b/src/main/java/com/url/shortener/utils/UrlConnectionUtil.java
@@ -1,0 +1,23 @@
+package com.url.shortener.utils;
+
+import java.net.URL;
+import java.net.URLConnection;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UrlConnectionUtil {
+
+    public static boolean isValidUrl(String address) {
+        try {
+            URL url = new URL(address);
+            URLConnection connection = url.openConnection();
+            connection.connect();
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
         format_sql: true
         hbm2ddl:
           auto: create-drop
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 
 env:
   short-url-domain: ${LOCAL_SHORT_URL_DOMAIN}

--- a/src/test/java/com/url/shortener/domain/UrlTest.java
+++ b/src/test/java/com/url/shortener/domain/UrlTest.java
@@ -1,0 +1,23 @@
+package com.url.shortener.domain;
+
+import static com.url.shortener.exception.ExceptionRule.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.url.shortener.exception.UrlException;
+
+class UrlTest {
+
+    @ParameterizedTest
+    @DisplayName("올바르지 않은 형식의 URL 주소를 이용해 url 객체를 만들 때, 예외가 발생한다.")
+    @ValueSource(strings = {"", " ", "abcde", "https://www.google", "https://www.ldskfjiwlenvbl.com/"})
+    void 올바르지_않은_URL_객체_생성_예외_테스트(String inValidOriginalUrl) {
+        //when, then
+        assertThatThrownBy(() -> Url.from(inValidOriginalUrl))
+            .isInstanceOf(UrlException.class)
+            .hasMessage(ORIGINAL_URL_INVALID.getMessage());
+    }
+}

--- a/src/test/java/com/url/shortener/utils/UrlConnectionUtilTest.java
+++ b/src/test/java/com/url/shortener/utils/UrlConnectionUtilTest.java
@@ -1,0 +1,32 @@
+package com.url.shortener.utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UrlConnectionUtilTest {
+
+    @ParameterizedTest
+    @DisplayName("올바른 형식의 URL에 대해 true를 반환한다.")
+    @ValueSource(strings = {"https://www.google.co.kr/", "https://www.naver.com/"})
+    void 올바른_형식_URL_테스트(String validOriginalUrl) {
+        //when
+        boolean isValid = UrlConnectionUtil.isValidUrl(validOriginalUrl);
+
+        //then
+        assertThat(isValid).isTrue();
+    }
+
+    @ParameterizedTest
+    @DisplayName("올바르지 않은 형식의 URL에 대해 false를 반환한다.")
+    @ValueSource(strings = {"", " ", "abcde", "https://www.google", "https://www.ldskfjiwlenvbl.com/"})
+    void 올바르지_않은_형식_URL_테스트(String inValidOriginalUrl) {
+        //when
+        boolean isValid = UrlConnectionUtil.isValidUrl(inValidOriginalUrl);
+
+        //then
+        assertThat(isValid).isFalse();
+    }
+}


### PR DESCRIPTION
## PR 설명
> 이슈 #6 
- DTO 예외 처리
- 비즈니스 로직 예외 처리
- 그 밖의 전역 예외 처리

---

## 작업 완료 목록
- [x] ExceptionRule, BusinessException, CustomException, GlobalExceptionHandler 추가
- [x] Request DTO bean validation 추가
- [x] CREATE 시, 현재 접속 가능한 url인지에 대한 예외처리
- [x] READ 시, 존재하지 않는 레코드에 대한 예외처리
- [x] short url 요청 시, 존재하지 않거나 형식이 올바르지 않은 key에 대한 예외처리
- [x] 기타 예외처리 (404, 405, 500)
- [x] 예외처리에 대한 단위 테스트 코드 작성

---

## 예외처리 내역
- `POST /api/short-urls` (Short URL 생성)
  - Original URL이 URL 형식이 아닌 경우
  - Original URL이 접속 가능하지 않은 경우
  - Short URL을 단축하려고 하는 경우
- `GET /api/short-urls/{id}` (Short URL 조회)
  - id에 해당하는 Short URL이 없는 경우
- `GET /{key}` (Short URL 접속)
  - key에 해당하는 Short URL이 없는 경우
- 공통 예외 처리
  - 404 NOT FOUND
  - 405 METHOD NOT ALLOWED
  - 500 INTERNAL SERVER ERROR