### PR TITLE
[#11] 프로젝트 프로필 분리 및 배포 자동화

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -2,7 +2,7 @@ name: cd-dev
 
 on:
   push:
-    branches: ["main", "dev"]
+    branches: [ "main" ]
 
 jobs:
   deploy-to-ec2:
@@ -13,26 +13,26 @@ jobs:
     steps:
       - name: github-checkout
         uses: actions/checkout@v3
-      
+
       - name: jdk-setting
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
-      
+
       - name: build-with-gradle
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
         env:
           LOCAL_SERVER_BASE_URL: ${{ secrets.LOCAL_SERVER_BASE_URL }}
-      
+
       - name: docker-emulator-setting
         uses: docker/setup-qemu-action@v2
-      
+
       - name: docker-buildx-setting
         uses: docker/setup-buildx-action@v2
-      
+
       - name: docker-hub-login
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -1,0 +1,91 @@
+name: cd-dev
+
+on:
+  push:
+    branches: ["main", "dev"]
+
+jobs:
+  deploy-to-ec2:
+    environment: dev
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: github-checkout
+        uses: actions/checkout@v3
+      
+      - name: jdk-setting
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      
+      - name: build-with-gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+        env:
+          LOCAL_SERVER_BASE_URL: ${{ secrets.LOCAL_SERVER_BASE_URL }}
+      
+      - name: docker-emulator-setting
+        uses: docker/setup-qemu-action@v2
+      
+      - name: docker-buildx-setting
+        uses: docker/setup-buildx-action@v2
+      
+      - name: docker-hub-login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: docker-build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.DOCKER_HUB_TAG }}
+          platforms: linux/arm64
+
+      - name: docker-env-file
+        run: |
+          cd ./deploy/dev
+          echo '#!/bin/sh' >> .env
+          echo 'DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}' >> .env
+          echo 'DOCKER_HUB_REPOSITORY=${{ secrets.DOCKER_HUB_REPOSITORY }}' >> .env
+          echo 'DOCKER_HUB_TAG=${{ secrets.DOCKER_HUB_TAG }}' >> .env
+
+      - name: spring-env-file
+        run: |
+          cd ./deploy/dev
+          echo '#!/bin/sh' >> dev.env
+          echo 'DEV_DATASOURCE_URL=${{ secrets.DEV_DATASOURCE_URL }}' >> dev.env
+          echo 'DEV_DATASOURCE_USERNAME=${{ secrets.DEV_DATASOURCE_USERNAME }}' >> dev.env
+          echo 'DEV_DATASOURCE_PASSWORD=${{ secrets.DEV_DATASOURCE_PASSWORD }}' >> dev.env
+          echo 'DEV_SERVER_BASE_URL=${{ secrets.DEV_SERVER_BASE_URL }}' >> dev.env
+          echo 'DEV_CLIENT_BASE_URL=${{ secrets.DEV_CLIENT_BASE_URL }}' >> dev.env
+
+      - name: copy-to-ec2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_INSTANCE_HOST }}
+          port: ${{ secrets.EC2_INSTANCE_PORT }}
+          username: ${{ secrets.EC2_INSTANCE_USERNAME }}
+          key: ${{ secrets.EC2_INSTANCE_PRIVATE_KEY }}
+          source: './deploy/dev/*'
+          target: '~/urlShortener/deploy'
+          strip_components: 1
+
+      - name: docker-compose
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_INSTANCE_HOST }}
+          port: ${{ secrets.EC2_INSTANCE_PORT }}
+          username: ${{ secrets.EC2_INSTANCE_USERNAME }}
+          key: ${{ secrets.EC2_INSTANCE_PRIVATE_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.DOCKER_HUB_TAG }}
+            cd ~/urlShortener/deploy/dev
+            docker-compose -p url-shortener-dev down
+            docker-compose -p url-shortener-dev up -d
+            docker image prune -f

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      LOCAL_SERVER_BASE_URL: ${{ secrets.LOCAL_SERVER_BASE_URL }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        with:
+          arguments: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:17-jdk-jammy
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -35,3 +35,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}

--- a/deploy/dev/docker-compose.yaml
+++ b/deploy/dev/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  spring:
+    image: ${DOCKER_HUB_USERNAME}/${DOCKER_HUB_REPOSITORY}:${DOCKER_HUB_TAG}
+    container_name: ${DOCKER_HUB_REPOSITORY}
+    ports:
+      - "8081:8081"
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+    env_file:
+      - dev.env

--- a/src/main/java/com/url/shortener/config/MvcConfiguration.java
+++ b/src/main/java/com/url/shortener/config/MvcConfiguration.java
@@ -2,11 +2,13 @@ package com.url.shortener.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Profile({"local", "dev"})
 public class MvcConfiguration implements WebMvcConfigurer {
 
     @Value("${env.client-base-url}")

--- a/src/main/java/com/url/shortener/domain/Url.java
+++ b/src/main/java/com/url/shortener/domain/Url.java
@@ -35,10 +35,10 @@ import lombok.NoArgsConstructor;
 public class Url {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 1000, nullable = false, unique = true)
+    @Column(length = 1000, nullable = false)
     private String originalUrl;
 
     @Column(length = 10, unique = true)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,16 +1,8 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DEV_DATASOURCE_URL}
     username: ${DEV_DATASOURCE_USERNAME}
     password: ${DEV_DATASOURCE_PASSWORD}
-  jpa:
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        query.in_clause_parameter_padding: true
-
 
 env:
   server-base-url: ${DEV_SERVER_BASE_URL}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DEV_DATASOURCE_URL}
+    username: ${DEV_DATASOURCE_USERNAME}
+    password: ${DEV_DATASOURCE_PASSWORD}
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        query.in_clause_parameter_padding: true
+
+
+env:
+  server-base-url: ${DEV_SERVER_BASE_URL}
+  client-base-url: ${DEV_CLIENT_BASE_URL}
+
+server:
+  port: 8081

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${LOCAL_DATASOURCE_URL}
+    username: ${LOCAL_DATASOURCE_USERNAME}
+    password: ${LOCAL_DATASOURCE_PASSWORD}
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        query.in_clause_parameter_padding: true
+
+env:
+  server-base-url: ${LOCAL_SERVER_BASE_URL}
+  client-base-url: ${LOCAL_CLIENT_BASE_URL}
+
+server:
+  port: 8080

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,15 +1,8 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${LOCAL_DATASOURCE_URL}
     username: ${LOCAL_DATASOURCE_USERNAME}
     password: ${LOCAL_DATASOURCE_PASSWORD}
-  jpa:
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        query.in_clause_parameter_padding: true
 
 env:
   server-base-url: ${LOCAL_SERVER_BASE_URL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,30 +1,8 @@
 spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:urlShortener
-    username: sa
-    password:
-  h2:
-    console:
-      path: /h2-console
-      enabled: true
-  jpa:
-    generate-ddl: true
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        query.in_clause_parameter_padding: true
-        show_sql: true
-        format_sql: true
-        hbm2ddl:
-          auto: create-drop
+  profiles:
+    default: local
   mvc:
     throw-exception-if-no-handler-found: true
   web:
     resources:
       add-mappings: false
-
-env:
-  server-base-url: ${LOCAL_SERVER_BASE_URL}
-  client-base-url: ${LOCAL_CLIENT_BASE_URL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,14 @@
 spring:
   profiles:
     default: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        query.in_clause_parameter_padding: true
   mvc:
     throw-exception-if-no-handler-found: true
   web:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:urlShortener
+    username: sa
+    password:
+  jpa:
+    generate-ddl: true
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        query.in_clause_parameter_padding: true
+        show_sql: true
+        format_sql: true
+        hbm2ddl:
+          auto: create-drop
+
+env:
+  server-base-url: ${LOCAL_SERVER_BASE_URL}


### PR DESCRIPTION
## PR 설명
> 이슈 #11 
- Github Actions와 AWS를 이용한 배포 자동화 구축해보기

---

## 작업 완료 목록
- [x] 프로젝트 test, local, dev 환경 분리
- [x] EC2와 docker를 이용한 springboot 프로젝트 배포
- [x] 테스트 및 배포 자동화 스크립트 작성 (ci, cd yaml)
- [x] 가비아에서 도메인 구매
- [x] Route53 이용한 프론트엔드, 백엔드 도메인 변경
- [x] S3 이용한 정적 웹사이트 호스팅 (Vue 프로젝트 빌드 파일 업로드)

---

## 기타 사항
- 프론트엔드 도메인 : http://app.url-shorten.site/
  - 단축 URL 생성 및 조회 기능을 제공하는 페이지입니다. (app이라는 prefix로 구분)
- 백엔드 도메인 : http://url-shorten.site/
  - api 도메인 및 단축 URL의 리다이렉트 도메인입니다. (사용자들이 받게 될 단축 URL은 해당 도메인을 사용)